### PR TITLE
Handle allocation failures and align build script with source name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Repository Contribution Guidelines
 
-- Follow the existing C coding style in `smart_terminal.c` (brace placement, indentation of four spaces) unless a more specific instruction overrides it in a subdirectory.
+- Follow the existing C coding style in `smartTerm.c` (brace placement, indentation of four spaces) unless a more specific instruction overrides it in a subdirectory.
 - When modifying the agent loop protections, ensure new logic preserves user-facing messaging and does not reduce existing safety guards.
 - Prefer descriptive, user-oriented status messages when adding new output so that end users understand why automation paused or continued.

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ CFLAGS = -Wall -g -std=c99
 LDFLAGS = -lcurl -ljson-c
 
 # Target executable name
-TARGET = smart_terminal
+TARGET = smartTerm
 
 # Source file
-SRC = smart_terminal.c
+SRC = smartTerm.c
 
 # Phony targets
 .PHONY: all clean install

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The project ships with a standard `Makefile`. To build the executable, ensure th
 make
 ```
 
-This will compile the `smart_terminal` binary. To remove build artifacts, run `make clean`. You can install the binary system-wide with `sudo make install`.
+This will compile the `smartTerm` binary. To remove build artifacts, run `make clean`. You can install the binary system-wide with `sudo make install`.
 
 ## Basic Controls
 

--- a/smartTerm.c
+++ b/smartTerm.c
@@ -113,6 +113,10 @@ char* execute_and_capture(const char* command) {
     FILE *fp;
     char buffer[1024];
     char *output = malloc(1);
+    if (!output) {
+        fprintf(stderr, "Error: unable to allocate memory for command output.\n");
+        return strdup("Command output unavailable: memory allocation failed.");
+    }
     output[0] = '\0';
     size_t output_size = 1;
     char full_command[2048];
@@ -203,8 +207,13 @@ void parse_webui_action(const char *json_string, AIAction *ai_action) {
 }
 
 void get_ai_action(const char* user_prompt, AIAction *ai_action) {
+    memset(ai_action, 0, sizeof(*ai_action));
     CURL *curl;
     struct MemoryStruct chunk = { .memory = malloc(1), .size = 0 };
+    if (!chunk.memory) {
+        fprintf(stderr, "Error: unable to allocate memory for response buffer.\n");
+        return;
+    }
     curl_global_init(CURL_GLOBAL_ALL);
     curl = curl_easy_init();
     if (curl) {
@@ -263,7 +272,7 @@ void free_ai_action(AIAction *action) {
     if (action->action) free(action->action);
     if (action->command) free(action->command);
     if (action->filename) free(action->filename);
-    if (action->content) free(action.content);
+    if (action->content) free(action->content);
     if (action->answer) free(action->answer);
     if (action->question) free(action->question);
 }


### PR DESCRIPTION
## Summary
- guard the smartTerm command execution and API fetch paths against allocation failures and fix the action cleanup routine
- update the Makefile target/source names to match smartTerm.c and adjust the README accordingly
- refresh the contributor guidance so it points to the correct C source file name

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68dd7f5fcf908326ad103b28a3f8dfb1